### PR TITLE
Partially queue instantiations of templated function definitions.

### DIFF
--- a/src/yume/compiler/vals.cpp
+++ b/src/yume/compiler/vals.cpp
@@ -9,4 +9,17 @@ auto Fn::declaration(Compiler& compiler, bool mangle) -> llvm::Function* {
   }
   return m_llvm_fn;
 }
+
+auto Fn::create_template_instantiation(Instantiation& instantiate) -> Fn& {
+  auto* decl_clone = m_ast_decl.clone();
+  m_member->direct_body().emplace_back(decl_clone);
+
+  std::map<string, const ty::Type*> subs{};
+  for (const auto& [k, v] : instantiate.sub)
+    subs.try_emplace(k->name(), v);
+
+  auto fn_ptr = std::make_unique<Fn>(*decl_clone, m_parent, m_member, move(subs));
+  auto new_emplace = m_instantiations.emplace(instantiate, move(fn_ptr));
+  return *new_emplace.first->second;
+}
 } // namespace yume

--- a/src/yume/compiler/vals.hpp
+++ b/src/yume/compiler/vals.hpp
@@ -77,6 +77,8 @@ struct Fn {
 
   [[nodiscard]] auto declaration(Compiler& compiler, bool mangle = true) -> llvm::Function*;
 
+  [[nodiscard]] auto create_template_instantiation(Instantiation& instantiate) -> Fn&;
+
   operator llvm::Function*() const { return m_llvm_fn; }
 };
 

--- a/src/yume/semantic/type_walker.cpp
+++ b/src/yume/semantic/type_walker.cpp
@@ -55,6 +55,8 @@ template <> void TypeWalker::expression(ast::TypeName& expr) {
   expression(type);
 }
 
+template <> void TypeWalker::expression(ast::ImplicitCastExpr& expr) { body_expression(expr.base()); }
+
 template <> void TypeWalker::expression(ast::CtorExpr& expr) {
   for (auto& i : expr.args()) {
     body_expression(i);


### PR DESCRIPTION
Previous, resolved TODOs:
```
// TODO: Push this in a queue to not cause a huge stack trace when an instantiation causes another instantiation
// TODO: This really needs to go into a queue because an instantiation can loop back to requiring to instantiate
// itself while the first instantiation hasn't finished existing this scope yet, leading to god knows what
// outcome.
```

new todos:
```
// The types of the instantiated function must be set immediately (i.e. with in_depth = false)
// This is because the implicit cast logic below depends on the direct type being set here and bound type
// information doesn't propagate across ImplicitCastExpr...
// TODO: Find a better solution; such as moving cast logic also into queue?
// However that would require evaluation of the queue very eagerly (i.e. immediately when the function is used,
// which kinda defeats the purpose of the queue). So I guess we'll just keep this until I think of a better
// solution
// TODO: find a better solution other than the solution proposed above  
```

Hey look, we broke even!