### PR TITLE
Language change: Slice literals now require a colon between the type name and the opening [

### DIFF
--- a/example/slice.ym
+++ b/example/slice.ym
@@ -1,5 +1,5 @@
 def hello()
-  let a = U8[?h, ?e, ?l, ?l, ?o]
+  let a = U8:[?h, ?e, ?l, ?l, ?o]
   printf("string: %s\n", a.c_str)
   printf("size of a: %d\n", a.size)
   printf("size of a.c_str: %d\n", a.c_str.size)

--- a/test/parser_test.cpp
+++ b/test/parser_test.cpp
@@ -180,13 +180,14 @@ TEST_CASE("Parse constructor calling", "[parse]") {
 }
 
 TEST_CASE("Parse slice literal", "[parse]") {
-  CHECK_PARSER("I32[1, 2, 3]", make_call<SliceExpr>("I32"_Type, 1_Num, 2_Num, 3_Num));
-  CHECK_PARSER("I32[]", make_call<SliceExpr>("I32"_Type));
+  CHECK_PARSER("I32:[1, 2, 3]", make_call<SliceExpr>("I32"_Type, 1_Num, 2_Num, 3_Num));
+  CHECK_PARSER("I32:[]", make_call<SliceExpr>("I32"_Type));
 }
 
 TEST_CASE("Parse bare type", "[parse][throws]") {
   CHECK_PARSER_THROWS("T ptr");
   CHECK_PARSER_THROWS("I32");
+  CHECK_PARSER_THROWS("I32[]");
 }
 
 TEST_CASE("Parse index operator", "[parse]") {


### PR DESCRIPTION
This is to distinguish it better from slice types, especially in the case of the empty slice, which was previously sorta ambiguous.

For example, previously, `I32[]` would have been an empty slice of I32, but it is also the type `I32[]`. Since a type on its own isn't a valid expression, there was no ambiguity, but this may be wanted in the future.

Now, an empty slice literal is `I32:[]`.