### PR TITLE
Destructors

### DIFF
--- a/example/bf.ym
+++ b/example/bf.ym
@@ -5,10 +5,10 @@ end
 
 def parse(input U8[]) Instruction[]
   let i = 0
-  let instructions = Instruction[](input.size) # `instructions` ALLOCATED
+  let instructions = Instruction[](input.size)
   # TODO
   # This should be dynamically sized...
-  let stack = I32[](512) # `stack` ALLOCATED
+  let stack = I32[](512)
   let stack_i = 0
   # TODO
   # This could be simplified if i had better iteration, i.e. something akin
@@ -40,12 +40,8 @@ def parse(input U8[]) Instruction[]
     i = i + 1
   end
 
-  free(stack) # `stack` SHOULD DEALLOCATE
-
-  return instructions # LIFETIME OF `instructions` PASSED ON
+  return instructions
 end
-
-def free<T>(arr T[]) = __primitive__(slice_free)
 
 def main(argc I32, argv U8 ptr ptr) I32
   # Hello world example function
@@ -57,14 +53,14 @@ def main(argc I32, argv U8 ptr ptr) I32
   # Perhaps this could be constructed from the same pointer, instead of
   # allocating a new one and copying it. It would probably require constructors
   # to be a real feature, but slice constructors are a special case anyway
-  let word = U8[](word_ptr.c_len) # `word` ALLOCATED
+  let word = U8[](word_ptr.c_len)
   copy(word_ptr, word.unsafe_ptr, word.size)
 
-  let instructions = parse(word) # RECEIVED `instructions` WITH RUNNING LIFETIME
+  let instructions = parse(word)
 
   let pc I32 = 0
   let ptr I32 = 0
-  let memory = U8[](65535) # `memory` ALLOCATED
+  let memory = U8[](65535)
 
   while pc < instructions.size
     let instr = instructions[pc]
@@ -95,10 +91,6 @@ def main(argc I32, argv U8 ptr ptr) I32
     end
     pc = pc + 1
   end
-
-  free(instructions) # `instructions` SHOULD DEALLOCATE
-  free(word) # `word` SHOULD DEALLOCATE
-  free(memory) # `memory` SHOULD DEALLOCATE
 
   return 0
 end

--- a/example/bf.ym
+++ b/example/bf.ym
@@ -5,10 +5,10 @@ end
 
 def parse(input U8[]) Instruction[]
   let i = 0
-  let instructions = Instruction[](input.size)
+  let instructions = Instruction[](input.size) # `instructions` ALLOCATED
   # TODO
   # This should be dynamically sized...
-  let stack = I32[](512)
+  let stack = I32[](512) # `stack` ALLOCATED
   let stack_i = 0
   # TODO
   # This could be simplified if i had better iteration, i.e. something akin
@@ -39,8 +39,13 @@ def parse(input U8[]) Instruction[]
     instructions[i] = instruction
     i = i + 1
   end
-  return instructions
+
+  free(stack) # `stack` SHOULD DEALLOCATE
+
+  return instructions # LIFETIME OF `instructions` PASSED ON
 end
+
+def free<T>(arr T[]) = __primitive__(slice_free)
 
 def main(argc I32, argv U8 ptr ptr) I32
   # Hello world example function
@@ -52,14 +57,14 @@ def main(argc I32, argv U8 ptr ptr) I32
   # Perhaps this could be constructed from the same pointer, instead of
   # allocating a new one and copying it. It would probably require constructors
   # to be a real feature, but slice constructors are a special case anyway
-  let word = U8[](word_ptr.c_len)
+  let word = U8[](word_ptr.c_len) # `word` ALLOCATED
   copy(word_ptr, word.unsafe_ptr, word.size)
 
-  let instructions = parse(word)
+  let instructions = parse(word) # RECEIVED `instructions` WITH RUNNING LIFETIME
 
   let pc I32 = 0
   let ptr I32 = 0
-  let memory = U8[](65535)
+  let memory = U8[](65535) # `memory` ALLOCATED
 
   while pc < instructions.size
     let instr = instructions[pc]
@@ -90,6 +95,10 @@ def main(argc I32, argv U8 ptr ptr) I32
     end
     pc = pc + 1
   end
+
+  free(instructions) # `instructions` SHOULD DEALLOCATE
+  free(word) # `word` SHOULD DEALLOCATE
+  free(memory) # `memory` SHOULD DEALLOCATE
 
   return 0
 end

--- a/src/yume/ast/ast.hpp
+++ b/src/yume/ast/ast.hpp
@@ -506,7 +506,7 @@ public:
 };
 
 /// A destruction of an object upon leaving its scope.
-class DtorExpr : public Expr {
+class [[deprecated]] DtorExpr : public Expr {
   unique_ptr<Expr> m_base;
 
 public:

--- a/src/yume/ast/clone.cpp
+++ b/src/yume/ast/clone.cpp
@@ -71,6 +71,7 @@ auto Compound::clone() const -> Compound* { return new Compound(tok(), dup(m_bod
 auto VarExpr::clone() const -> VarExpr* { return new VarExpr(tok(), m_name); }
 auto CallExpr::clone() const -> CallExpr* { return new CallExpr(tok(), m_name, dup(m_args)); }
 auto CtorExpr::clone() const -> CtorExpr* { return new CtorExpr(tok(), dup(m_type), dup(m_args)); }
+auto DtorExpr::clone() const -> DtorExpr* { return new DtorExpr(tok(), dup(m_base)); }
 auto SliceExpr::clone() const -> SliceExpr* { return new SliceExpr(tok(), dup(m_type), dup(m_args)); }
 auto AssignExpr::clone() const -> AssignExpr* { return new AssignExpr(tok(), dup(m_target), dup(m_value)); }
 auto FieldAccessExpr::clone() const -> FieldAccessExpr* { return new FieldAccessExpr(tok(), dup(m_base), m_field); }

--- a/src/yume/ast/crtp_walker.hpp
+++ b/src/yume/ast/crtp_walker.hpp
@@ -36,7 +36,7 @@ public:
     case ast::K_Var: return conv_expression<ast::VarExpr>(expr, args...);
     case ast::K_Assign: return conv_expression<ast::AssignExpr>(expr, args...);
     case ast::K_Ctor: return conv_expression<ast::CtorExpr>(expr, args...);
-    case ast::K_Dtor: return conv_expression<ast::DtorExpr>(expr, args...);
+    // case ast::K_Dtor: return conv_expression<ast::DtorExpr>(expr, args...);
     case ast::K_Slice: return conv_expression<ast::SliceExpr>(expr, args...);
     case ast::K_FieldAccess: return conv_expression<ast::FieldAccessExpr>(expr, args...);
     case ast::K_ImplicitCast: return conv_expression<ast::ImplicitCastExpr>(expr, args...);

--- a/src/yume/ast/crtp_walker.hpp
+++ b/src/yume/ast/crtp_walker.hpp
@@ -36,6 +36,7 @@ public:
     case ast::K_Var: return conv_expression<ast::VarExpr>(expr, args...);
     case ast::K_Assign: return conv_expression<ast::AssignExpr>(expr, args...);
     case ast::K_Ctor: return conv_expression<ast::CtorExpr>(expr, args...);
+    case ast::K_Dtor: return conv_expression<ast::DtorExpr>(expr, args...);
     case ast::K_Slice: return conv_expression<ast::SliceExpr>(expr, args...);
     case ast::K_FieldAccess: return conv_expression<ast::FieldAccessExpr>(expr, args...);
     case ast::K_ImplicitCast: return conv_expression<ast::ImplicitCastExpr>(expr, args...);

--- a/src/yume/ast/visit.cpp
+++ b/src/yume/ast/visit.cpp
@@ -41,6 +41,7 @@ void Compound::visit(Visitor& visitor) const { visitor.visit(m_body); }
 void VarExpr::visit(Visitor& visitor) const { visitor.visit(m_name); }
 void CallExpr::visit(Visitor& visitor) const { visitor.visit(m_name).visit(m_args); }
 void CtorExpr::visit(Visitor& visitor) const { visitor.visit(m_type).visit(m_args); }
+void DtorExpr::visit(Visitor& visitor) const { visitor.visit(m_base); }
 void SliceExpr::visit(Visitor& visitor) const { visitor.visit(m_type).visit(m_args); }
 void AssignExpr::visit(Visitor& visitor) const { visitor.visit(m_target).visit(m_value); }
 void FieldAccessExpr::visit(Visitor& visitor) const { visitor.visit(m_base).visit(m_field); }

--- a/src/yume/compiler/compiler.cpp
+++ b/src/yume/compiler/compiler.cpp
@@ -512,6 +512,10 @@ template <> auto Compiler::expression(const ast::CallExpr& expr, bool mut) -> Va
           return m_builder->CreateStructGEP(result_type, args.at(0), 0, "sl.ptr.mut");
         }
         return m_builder->CreateExtractValue(args.at(0), 0, "sl.ptr.x");
+      } else if (primitive == "slice_free") {
+        auto* ptr = m_builder->CreateExtractValue(args.at(0), 0, "sl.ptr.free");
+        auto* call = llvm::CallInst::CreateFree(ptr, m_builder->GetInsertBlock());
+        return m_builder->Insert(call);
       } else if (primitive == "slice_dup") {
         return m_builder->CreateInsertValue(
             args.at(0), m_builder->CreateAdd(m_builder->CreateExtractValue(args.at(0), 1), args.at(1)), 1);

--- a/src/yume/compiler/compiler.cpp
+++ b/src/yume/compiler/compiler.cpp
@@ -584,10 +584,6 @@ template <> auto Compiler::expression(const ast::CallExpr& expr, bool mut) -> Va
           return m_builder->CreateStructGEP(result_type, args.at(0), 0, "sl.ptr.mut");
         }
         return m_builder->CreateExtractValue(args.at(0), 0, "sl.ptr.x");
-      } else if (primitive == "slice_free") {
-        auto* ptr = m_builder->CreateExtractValue(args.at(0), 0, "sl.ptr.free");
-        auto* call = llvm::CallInst::CreateFree(ptr, m_builder->GetInsertBlock());
-        return m_builder->Insert(call);
       } else if (primitive == "slice_dup") {
         return m_builder->CreateInsertValue(
             args.at(0), m_builder->CreateAdd(m_builder->CreateExtractValue(args.at(0), 1), args.at(1)), 1);

--- a/src/yume/compiler/compiler.cpp
+++ b/src/yume/compiler/compiler.cpp
@@ -731,8 +731,6 @@ template <> auto Compiler::expression(const ast::CtorExpr& expr, bool mut) -> Va
     auto* array_alloc = llvm::CallInst::CreateMalloc(m_builder->GetInsertBlock(), m_builder->getInt32Ty(), base_type,
                                                      alloc_size, array_size, nullptr, "sl.ctor.malloc");
 
-    // TODO: the above `malloc` is literally never `free`d because the language doesn't yet have destructors.
-
     auto* data_ptr = m_builder->Insert(array_alloc);
     auto* data_size = m_builder->CreateSExtOrBitCast(slice_size, m_builder->getInt64Ty());
     llvm::Value* slice_inst = llvm::UndefValue::get(llvm_slice_type);

--- a/src/yume/compiler/compiler.hpp
+++ b/src/yume/compiler/compiler.hpp
@@ -34,6 +34,12 @@ class Type;
 }
 using namespace llvm;
 
+struct InScope {
+  Val value;
+  const ast::AST& ast;
+  bool owning{};
+};
+
 /// The `Compiler` the the primary top-level type during compilation. A single instance is created during the
 /// compilation process.
 class Compiler : public CRTPWalker<Compiler> {
@@ -45,7 +51,7 @@ class Compiler : public CRTPWalker<Compiler> {
   unique_ptr<semantic::TypeWalker> m_walker;
 
   Fn* m_current_fn{};
-  std::map<string, Val> m_scope{};
+  std::map<string, InScope> m_scope{};
 
   unique_ptr<LLVMContext> m_context;
   unique_ptr<IRBuilder<>> m_builder;
@@ -96,6 +102,8 @@ private:
   template <typename T> auto expression(const T& expr, [[maybe_unused]] bool mut = false) -> Val {
     throw std::runtime_error("Unknown expression "s + expr.kind_name());
   }
+
+  void destruct_all_in_scope(ast::FnDecl& scope_parent);
 
   auto known_type(const string& str) -> ty::Type&;
 

--- a/src/yume/compiler/compiler.hpp
+++ b/src/yume/compiler/compiler.hpp
@@ -81,6 +81,7 @@ public:
 
   /// Default-constructs an object of specified type
   auto default_init(const ty::Type& type) -> Val;
+  void destruct(Val val, const ty::Type& type);
 
   auto mangle_name(const Fn& fn_decl) -> string;
   auto mangle_name(const ty::Type& ast_type, const Fn& parent) -> string;

--- a/src/yume/semantic/type_walker.cpp
+++ b/src/yume/semantic/type_walker.cpp
@@ -129,7 +129,7 @@ template <> void TypeWalker::expression(ast::AssignExpr& expr) {
 template <> void TypeWalker::expression(ast::VarExpr& expr) {
   if (!m_scope.contains(expr.name()))
     throw std::runtime_error("Scope doesn't contain variable called "s + expr.name());
-  expr.attach_to(m_scope.at(expr.name()).value);
+  expr.attach_to(m_scope.at(expr.name()));
 }
 
 template <> void TypeWalker::expression(ast::FieldAccessExpr& expr) {
@@ -267,37 +267,12 @@ template <> void TypeWalker::statement(ast::StructDecl& stat) {
     expression(i);
 }
 
-static inline auto is_trivially_destructible(const ty::Type* type) -> bool {
-  if (isa<ty::Int>(type))
-    return true;
-
-  if (isa<ty::Qual>(type))
-    return is_trivially_destructible(type->qual_base());
-
-  if (const auto* ptr_type = dyn_cast<ty::Ptr>(type))
-    return !ptr_type->has_qualifier(Qualifier::Slice);
-
-  if (const auto* struct_type = dyn_cast<ty::Struct>(type)) {
-    for (const auto& field : struct_type->fields()) {
-      if (is_trivially_destructible(field.val_ty()))
-        continue;
-
-      return false;
-    }
-
-    return true;
-  }
-
-  // A generic or something, shouldn't occur
-  throw std::logic_error("Cannot check if "s + type->name() + " is trivially destructible");
-}
-
 template <> void TypeWalker::statement(ast::FnDecl& stat) {
   m_scope.clear();
 
   for (auto& i : stat.args()) {
     expression(i);
-    m_scope.insert({i.name(), {.value = &i, .owning = false}}); // We don't own parameters
+    m_scope.insert({i.name(), &i});
   }
 
   if (stat.ret().has_value()) {
@@ -311,11 +286,6 @@ template <> void TypeWalker::statement(ast::FnDecl& stat) {
 
   if (m_in_depth && std::holds_alternative<ast::Compound>(stat.body()))
     statement(get<ast::Compound>(stat.body()));
-
-  for (const auto& [k, v] : m_scope) {
-    if (v.owning && !is_trivially_destructible(v.value->val_ty()))
-      llvm::errs() << "While exiting scope of " << stat.name() << ", should destruct " << k << ": " << v.value->val_ty()->name() << "\n";
-  }
 }
 
 template <> void TypeWalker::statement(ast::ReturnStmt& stat) {
@@ -323,9 +293,6 @@ template <> void TypeWalker::statement(ast::ReturnStmt& stat) {
     auto& returned = stat.expr()->get();
     body_expression(returned);
     m_current_fn->m_ast_decl.attach_to(&returned);
-
-    if (auto* returned_var = dyn_cast<ast::VarExpr>(&returned))
-      m_scope.at(returned_var->name()).owning = false; // Returning a local variable passes on ownership of it
   }
 }
 
@@ -337,7 +304,7 @@ template <> void TypeWalker::statement(ast::VarDecl& stat) {
   }
 
   stat.val_ty(&stat.init().val_ty()->known_mut());
-  m_scope.insert({stat.name(), {.value = &stat, .owning = true}});
+  m_scope.insert({stat.name(), &stat});
 }
 
 template <> void TypeWalker::statement(ast::IfStmt& stat) {

--- a/src/yume/semantic/type_walker.hpp
+++ b/src/yume/semantic/type_walker.hpp
@@ -3,6 +3,7 @@
 #include "ast/crtp_walker.hpp"
 #include "semantic/overload.hpp"
 #include "util.hpp"
+#include <llvm/Support/raw_ostream.h>
 #include <map>
 #include <queue>
 #include <stdexcept>
@@ -25,6 +26,11 @@ class Type;
 
 namespace yume::semantic {
 
+struct InScope {
+  ast::AST* value;
+  bool owning;
+};
+
 /// Determine the type information of AST nodes.
 /// This makes up most of the "semantic" phase of the compiler.
 struct TypeWalker : public CRTPWalker<TypeWalker, false> {
@@ -34,7 +40,7 @@ public:
   Compiler& m_compiler;
   Struct* m_current_struct{};
   Fn* m_current_fn{};
-  std::map<string, ast::AST*> m_scope{};
+  std::map<string, InScope> m_scope{};
 
   std::queue<DeclLike> m_decl_queue{};
 

--- a/src/yume/semantic/type_walker.hpp
+++ b/src/yume/semantic/type_walker.hpp
@@ -26,11 +26,6 @@ class Type;
 
 namespace yume::semantic {
 
-struct InScope {
-  ast::AST* value;
-  bool owning;
-};
-
 /// Determine the type information of AST nodes.
 /// This makes up most of the "semantic" phase of the compiler.
 struct TypeWalker : public CRTPWalker<TypeWalker, false> {
@@ -40,7 +35,7 @@ public:
   Compiler& m_compiler;
   Struct* m_current_struct{};
   Fn* m_current_fn{};
-  std::map<string, InScope> m_scope{};
+  std::map<string, ast::AST*> m_scope{};
 
   std::queue<DeclLike> m_decl_queue{};
 


### PR DESCRIPTION
Destructor logic is handled in the compiler. When reaching something which terminates the scope, i.e. a return or the end of the function declaration, all variables in scope which are not trivially destructible are freed of. Currently this only occurs with slices, which are `malloc`ed when constructed.

When returning a local variable which should be destructed, its lifetime is instead extended to the scope of the calling function. This isn't fully implemented, and will cause leaks if the return value is discarded, or dangling references if an rvalue-like item is returned

Note that there is no destructor syntax, or any way to define a custom one. There is a DtorExpr in the ast but it is not used (see below).

As for why the logic is in the compiler and not the type walker, I will probably regret this later, but it is currently very hard to insert arbitrary ast nodes before or after existing ones in the type walker.
i.e., when leaving a scope with a return, I want to insert `DtorExpr`s in *front* of the return.
This is more of a limitation of the ast system and will definitely cause technical debt later on

