### PR TITLE
Language change: use braces for type arguments

### DIFF
--- a/example/generic.ym
+++ b/example/generic.ym
@@ -1,4 +1,4 @@
-def larger<T>(a T, b T) T
+def larger{T}(a T, b T) T
   if a > b
     return a
   else

--- a/example/generic_struct.ym
+++ b/example/generic_struct.ym
@@ -1,4 +1,4 @@
-struct Array<T>(body T[], size I64)
+struct Array{T}(body T[], size I64)
   def capacity(self) I64 = self::body.size
   def size(self) I64 = self::size
 end
@@ -6,8 +6,8 @@ end
 def main() I32
   # TODO
   # There should be a better way to write integer literals of a certain type
-  let t1 = Array<I32>(I32:[], I64(0))
-  let t2 = Array<U8>(U8:[?a], I64(2))
-  let t3 = Array<I32>(I32:[], I64(1))
+  let t1 = Array{I32}(I32:[], I64(0))
+  let t2 = Array{U8}(U8:[?a], I64(2))
+  let t3 = Array{I32}(I32:[], I64(1))
   return I32(!((t1.size + 2) == t2.size)) + I32(!((t3.size + 1) == t2.size))
 end

--- a/lib/std.ym
+++ b/lib/std.ym
@@ -2,11 +2,11 @@ def printf(format U8 ptr) I32 = __primitive__(libc) __varargs__
 def puts(string U8 ptr) I32 = __primitive__(libc)
 def putchar(char I32) I32 = __primitive__(libc)
 
-def size<T>(arr T[]) I64 = __primitive__(slice_size)
-def unsafe_ptr<T>(arr T[]) T ptr = __primitive__(slice_ptr)
-def []<T>(ptr T ptr, offset I64) T mut = __primitive__(get_at)
-def []=<T>(ptr T ptr, offset I64, val T) T = __primitive__(set_at)
-def dup_internal<T>(arr T[], extra I64) T[] = __primitive__(slice_dup)
+def size{T}(arr T[]) I64 = __primitive__(slice_size)
+def unsafe_ptr{T}(arr T[]) T ptr = __primitive__(slice_ptr)
+def []{T}(ptr T ptr, offset I64) T mut = __primitive__(get_at)
+def []={T}(ptr T ptr, offset I64, val T) T = __primitive__(set_at)
+def dup_internal{T}(arr T[], extra I64) T[] = __primitive__(slice_dup)
 
 # TODO: most of these should be templated
 def +(a I32, b I32) I32 = __primitive__(ib_add)
@@ -35,14 +35,14 @@ def !(a Bool) Bool
   end
 end
 
-def []<T>(slice T[] mut, offset I64) T mut = slice.unsafe_ptr[offset]
-def []<T>(slice T[], offset I64) T = slice.unsafe_ptr[offset]
-def []=<T>(slice T[] mut, offset I64, val T) T
+def []{T}(slice T[] mut, offset I64) T mut = slice.unsafe_ptr[offset]
+def []{T}(slice T[], offset I64) T = slice.unsafe_ptr[offset]
+def []={T}(slice T[] mut, offset I64, val T) T
   slice.unsafe_ptr[offset] = val
   return val
 end
 
-def copy<T>(source T ptr, dest T ptr, amount I64)
+def copy{T}(source T ptr, dest T ptr, amount I64)
   let count I64 = amount
   while count > 0
     count = count - 1
@@ -50,13 +50,13 @@ def copy<T>(source T ptr, dest T ptr, amount I64)
   end
 end
 
-def dup<T>(arr T[], extra I64) T[]
+def dup{T}(arr T[], extra I64) T[]
   let dup_t T[] = arr.dup_internal(extra)
   copy(arr.unsafe_ptr, dup_t.unsafe_ptr, arr.size)
   return dup_t
 end
 
-def dup_append<T>(arr T[], last T) T[]
+def dup_append{T}(arr T[], last T) T[]
   let dup_t T[] = arr.dup_internal(1)
   copy(arr.unsafe_ptr, dup_t.unsafe_ptr, arr.size)
   dup_t[arr.size] = last

--- a/src/yume/ast/ast.cpp
+++ b/src/yume/ast/ast.cpp
@@ -47,8 +47,8 @@ static const TokenAtom SYM_LBRACE = {Token::Type::Symbol, "{"_a};
 static const TokenAtom SYM_RBRACE = {Token::Type::Symbol, "}"_a};
 static const TokenAtom SYM_EQ_EQ = {Token::Type::Symbol, "=="_a};
 static const TokenAtom SYM_NEQ = {Token::Type::Symbol, "!="_a};
-static const TokenAtom SYM_GT = {Token::Type::Symbol, ">"_a};
 static const TokenAtom SYM_LT = {Token::Type::Symbol, "<"_a};
+static const TokenAtom SYM_GT = {Token::Type::Symbol, ">"_a};
 static const TokenAtom SYM_PLUS = {Token::Type::Symbol, "+"_a};
 static const TokenAtom SYM_MINUS = {Token::Type::Symbol, "-"_a};
 static const TokenAtom SYM_PERCENT = {Token::Type::Symbol, "%"_a};
@@ -339,8 +339,8 @@ struct Parser {
       throw std::runtime_error("Expected capitalized name for struct decl");
 
     auto type_args = vector<string>{};
-    if (try_consume(SYM_LT))
-      consume_with_commas_until(SYM_GT, [&] { type_args.push_back(consume_word()); });
+    if (try_consume(SYM_LBRACE))
+      consume_with_commas_until(SYM_RBRACE, [&] { type_args.push_back(consume_word()); });
 
     consume(SYM_LPAREN);
     auto fields = vector<TypeName>{};
@@ -366,8 +366,8 @@ struct Parser {
     consume(KWD_DEF);
     const string name = parse_fn_name();
     auto type_args = vector<string>{};
-    if (try_consume(SYM_LT))
-      consume_with_commas_until(SYM_GT, [&] { type_args.push_back(consume_word()); });
+    if (try_consume(SYM_LBRACE))
+      consume_with_commas_until(SYM_RBRACE, [&] { type_args.push_back(consume_word()); });
 
     consume(SYM_LPAREN);
 
@@ -717,9 +717,9 @@ auto Parser::parse_type(bool implicit_self) -> unique_ptr<Type> {
       consume(SYM_LBRACKET);
       consume(SYM_RBRACKET);
       base = ast_ptr<QualType>(entry, move(base), Qualifier::Slice);
-    } else if (try_consume(SYM_LT)) {
+    } else if (try_consume(SYM_LBRACE)) {
       auto type_args = vector<unique_ptr<Type>>{};
-      consume_with_commas_until(SYM_GT, [&] { type_args.push_back(parse_type()); });
+      consume_with_commas_until(SYM_RBRACE, [&] { type_args.push_back(parse_type()); });
 
       base = ast_ptr<TemplatedType>(entry, move(base), move(type_args));
     } else {
@@ -755,9 +755,9 @@ auto Parser::try_parse_type() -> optional<unique_ptr<Type>> {
       consume(SYM_LBRACKET);
       consume(SYM_RBRACKET);
       base = ast_ptr<QualType>(entry, move(base), Qualifier::Slice);
-    } else if (try_consume(SYM_LT)) {
+    } else if (try_consume(SYM_LBRACE)) {
       auto type_args = vector<unique_ptr<Type>>{};
-      consume_with_commas_until(SYM_GT, [&] { type_args.push_back(parse_type()); });
+      consume_with_commas_until(SYM_RBRACE, [&] { type_args.push_back(parse_type()); });
 
       base = ast_ptr<TemplatedType>(entry, move(base), std::move(type_args));
     } else {

--- a/src/yume/ast/ast.hpp
+++ b/src/yume/ast/ast.hpp
@@ -319,14 +319,14 @@ public:
   void visit(Visitor& visitor) const override;
   [[nodiscard]] auto describe() const -> string override {
     stringstream ss{};
-    ss << "<";
+    ss << "{";
     int j = 0;
     for (const auto& i : m_type_args) {
       if (j++ > 0)
         ss << ",";
       ss << i->describe();
     }
-    ss << ">";
+    ss << "}";
     return ss.str();
   }
 

--- a/src/yume/token.cpp
+++ b/src/yume/token.cpp
@@ -182,7 +182,7 @@ public:
               {Token::Type::Symbol, is_exactly("==")},
               {Token::Type::Symbol, is_exactly("!=")},
               {Token::Type::Symbol, is_exactly("//")},
-              {Token::Type::Symbol, is_any_of(R"(()[]<>=:#%-+.,!/*\)")},
+              {Token::Type::Symbol, is_any_of(R"(()[]{}<>=:#%-+.,!/*\)")},
           })) {
         string message = "Tokenizer didn't recognize ";
         message += m_last;

--- a/test/parser_test.cpp
+++ b/test/parser_test.cpp
@@ -225,20 +225,20 @@ TEST_CASE("Parse short function declaration", "[parse][fn]") {
 }
 
 TEST_CASE("Parse templated function declaration", "[parse][fn]") {
-  CHECK_PARSER("def templated<T>()\nend", make_fn_decl("templated", {}, {"T"}, {}));
+  CHECK_PARSER("def templated{T}()\nend", make_fn_decl("templated", {}, {"T"}, {}));
 
-  CHECK_PARSER("def templated<T>(t T) T\nend", make_fn_decl("templated", {{"t", "T"_Type}}, {"T"}, "T"_Type));
+  CHECK_PARSER("def templated{T}(t T) T\nend", make_fn_decl("templated", {{"t", "T"_Type}}, {"T"}, "T"_Type));
 
-  CHECK_PARSER("def templated<T>(t T) T = t",
+  CHECK_PARSER("def templated{T}(t T) T = t",
                make_fn_decl("templated", {{"t", "T"_Type}}, {"T"}, "T"_Type, ast<ReturnStmt>("t"_Var)));
 
   CHECK_PARSER(
-      "def templated<T,U,V,X,Y,Z>(t T, u U, v V) X = Y() + Z()",
+      "def templated{T,U,V,X,Y,Z}(t T, u U, v V) X = Y() + Z()",
       make_fn_decl("templated", {{"t", "T"_Type}, {"u", "U"_Type}, {"v", "V"_Type}}, {"T", "U", "V", "X", "Y", "Z"},
                    "X"_Type,
                    ast<ReturnStmt>(make_call("+", make_call<CtorExpr>("Y"_Type), make_call<CtorExpr>("Z"_Type)))));
 
-  CHECK_PARSER("def templated<T>(slice T[], pointer T ptr, mutable T mut, mix T ptr[] mut)\nend",
+  CHECK_PARSER("def templated{T}(slice T[], pointer T ptr, mutable T mut, mix T ptr[] mut)\nend",
                make_fn_decl("templated",
                             {{"slice", "T"_Type & Slice},
                              {"pointer", "T"_Type & Ptr},

--- a/test/tokenizer_test.cpp
+++ b/test/tokenizer_test.cpp
@@ -103,6 +103,7 @@ TEST_CASE("Tokenize operators/symbols", "[token]") {
   }
 
   CHECK_TOKENIZER("[]", "["_Symbol, "]"_Symbol);
+  CHECK_TOKENIZER("{}", "{"_Symbol, "}"_Symbol);
 }
 
 TEST_CASE("Token stringification", "[token][str]") {


### PR DESCRIPTION
This means that generic structs that were previously `Foo<T>` are now `Foo{T}`, and generic methods that were previously `call<T>()` are now `call{T}()`.

Braces were, up until now, completely unused by the language. Although i had plans to use braces for callbacks/closures, this seems like the more sensible option. For closures, a multi-char delimiter could be used, i.e. `{|` or something (the specific token combination doesn't really matter much right now), but using a less noisy delimiter for type args is probably preferred over closured, which probably would use something like `do .. end` anyways.

Heavily inspired by Julia. Also inspired by this article: https://erik-engheim.medium.com/the-case-against-curly-braces-languages-dd0a55840fcb