### PR TITLE
refactor: Completely remove `Qualifier::Slice`

### DIFF
--- a/src/yume/ast/describe.cpp
+++ b/src/yume/ast/describe.cpp
@@ -12,7 +12,6 @@ auto AST::describe() const -> string { return string{"unknown "} + kind_name(); 
 auto QualType::describe() const -> string {
   switch (m_qualifier) {
   case Qualifier::Ptr: return "ptr";
-  case Qualifier::Slice: return "slice";
   case Qualifier::Mut: return "mut";
   default: return "";
   }

--- a/src/yume/ast/parser.cpp
+++ b/src/yume/ast/parser.cpp
@@ -178,7 +178,11 @@ auto Parser::parse_type(bool implicit_self) -> unique_ptr<Type> {
       // Don't consume the `[` unless the `]` is directly after; it might be a slice literal.
       consume(SYM_LBRACKET);
       consume(SYM_RBRACKET);
-      base = ast_ptr<QualType>(entry, move(base), Qualifier::Slice);
+
+      auto slice_ty = ast_ptr<SimpleType>(entry, "Slice");
+      auto type_args = vector<AnyType>{};
+      type_args.emplace_back(move(base));
+      base = ast_ptr<TemplatedType>(entry, move(slice_ty), move(type_args));
     } else if (try_consume(SYM_LBRACE)) {
       auto type_args = vector<AnyType>{};
       consume_with_commas_until(SYM_RBRACE, [&] { type_args.emplace_back(parse_type()); });
@@ -216,7 +220,11 @@ auto Parser::try_parse_type() -> optional<unique_ptr<Type>> {
       // Don't consume the `[` unless the `]` is directly after; it might be a slice literal.
       consume(SYM_LBRACKET);
       consume(SYM_RBRACKET);
-      base = ast_ptr<QualType>(entry, move(base), Qualifier::Slice);
+
+      auto slice_ty = ast_ptr<SimpleType>(entry, "Slice");
+      auto type_args = vector<AnyType>{};
+      type_args.emplace_back(move(base));
+      base = ast_ptr<TemplatedType>(entry, move(slice_ty), move(type_args));
     } else if (try_consume(SYM_LBRACE)) {
       auto type_args = vector<AnyType>{};
       consume_with_commas_until(SYM_RBRACE, [&] { type_args.emplace_back(parse_type()); });

--- a/src/yume/extra/mangle.cpp
+++ b/src/yume/extra/mangle.cpp
@@ -43,8 +43,6 @@ auto mangle_name(ty::Type ast_type, DeclLike parent) -> string {
     ss << mangle_name(ptr_type->pointee(), parent);
     if (ptr_type->has_qualifier(Qualifier::Ptr))
       ss << "*";
-    if (ptr_type->has_qualifier(Qualifier::Slice))
-      ss << "[";
   } else if (const auto* generic_type = ast_type.base_dyn_cast<ty::Generic>()) {
     auto match = parent.subs()->find(generic_type->name());
     yume_assert(match != parent.subs()->end(), "Cannot mangle unsubstituted generic");

--- a/src/yume/qualifier.hpp
+++ b/src/yume/qualifier.hpp
@@ -2,14 +2,12 @@
 
 namespace yume {
 enum struct Qualifier {
-  Ptr,   ///< `ptr`
-  Slice, ///< `[]`
-  Mut,   ///< `mut`
+  Ptr, ///< `ptr`
+  Mut, ///< `mut`
 };
 
 enum struct PtrLikeQualifier {
-  Ptr = static_cast<int>(Qualifier::Ptr),
-  Slice = static_cast<int>(Qualifier::Slice),
+  Ptr = static_cast<int>(Qualifier::Ptr), ///< `ptr`
   Q_END
 };
 } // namespace yume

--- a/src/yume/semantic/type_walker.hpp
+++ b/src/yume/semantic/type_walker.hpp
@@ -51,8 +51,8 @@ public:
 
 private:
   /// Convert an ast type (`ast::Type`) into a type in the type system (`ty::Type`).
-  auto convert_type(const ast::Type& ast_type) -> ty::Type;
-  auto convert_slice_type(const ty::Type& base_type) -> ty::Type;
+  auto convert_type(ast::Type& ast_type) -> ty::Type;
+  auto create_slice_type(const ty::Type& base_type) -> ty::Type;
 
   auto all_fn_overloads_by_name(ast::CallExpr& call) -> OverloadSet<Fn>;
   auto all_ctor_overloads_by_type(Struct& st, ast::CtorExpr& call) -> OverloadSet<Ctor>;

--- a/src/yume/ty/type.cpp
+++ b/src/yume/ty/type.cpp
@@ -16,7 +16,6 @@ static auto qual_suffix(Qualifier qual) -> string {
   switch (qual) {
   case Qualifier::Mut: return " mut";
   case Qualifier::Ptr: return " ptr";
-  case Qualifier::Slice: return "[]";
   default: return "";
   }
 }

--- a/src/yume/ty/type.cpp
+++ b/src/yume/ty/type.cpp
@@ -144,6 +144,13 @@ auto Type::is_generic() const noexcept -> bool {
   return false;
 }
 
+auto Type::is_slice() const noexcept -> bool {
+  if (const auto* base = base_dyn_cast<Struct>())
+    return base->base_name() == "Slice" && (base->m_subs != nullptr) && base->m_subs->size() == 1;
+
+  return false;
+};
+
 auto Type::has_qualifier(Qualifier qual) const -> bool {
   if (m_mut)
     return (qual == Qualifier::Mut);

--- a/src/yume/ty/type.hpp
+++ b/src/yume/ty/type.hpp
@@ -61,8 +61,8 @@ public:
 /// An user-defined struct type with associated fields.
 class Struct : public BaseType {
   vector<const ast::TypeName*> m_fields;
-  const Substitution* m_subs;
-  const Struct* m_parent{};
+  nullable<const Substitution*> m_subs;
+  nullable<const Struct*> m_parent{};
   mutable std::map<Substitution, unique_ptr<Struct>> m_subbed{}; // HACK
   auto emplace_subbed(Substitution sub) const -> const Struct&;
   mutable llvm::StructType* m_memo{};
@@ -73,7 +73,7 @@ class Struct : public BaseType {
   friend Type;
 
 public:
-  Struct(string name, vector<const ast::TypeName*> fields, const Substitution* subs)
+  Struct(string name, vector<const ast::TypeName*> fields, nullable<const Substitution*> subs)
       : BaseType(K_Struct, move(name)), m_fields(move(fields)), m_subs(subs) {}
   [[nodiscard]] auto fields() const -> const auto& { return m_fields; }
   [[nodiscard]] auto fields() -> auto& { return m_fields; }

--- a/src/yume/ty/type_base.hpp
+++ b/src/yume/ty/type_base.hpp
@@ -93,7 +93,6 @@ public:
   [[nodiscard]] auto known_qual(Qualifier qual) const -> Type;
   [[nodiscard]] auto known_ptr() const -> Type { return known_qual(Qualifier::Ptr); }
   [[nodiscard]] auto known_mut() const -> Type { return known_qual(Qualifier::Mut); }
-  [[nodiscard]] auto known_slice() const -> Type { return known_qual(Qualifier::Slice); }
 
   /// The union of this and `other`. For example, the union of `T` and `T mut` is `T mut`.
   /// \returns `nullopt` if an union cannot be created.

--- a/src/yume/ty/type_base.hpp
+++ b/src/yume/ty/type_base.hpp
@@ -102,6 +102,7 @@ public:
   [[nodiscard]] auto intersect(Type other) const noexcept -> optional<Type>;
 
   [[nodiscard]] auto is_mut() const noexcept -> bool { return m_mut; };
+  [[nodiscard]] auto is_slice() const noexcept -> bool;
   [[nodiscard]] auto is_generic() const noexcept -> bool;
 
   /// If this type is a mutable reference, return the base of it (`T mut` -> `T`)

--- a/test/parser_test.cpp
+++ b/test/parser_test.cpp
@@ -117,7 +117,16 @@ template <typename... Ts> auto equals_ast(Ts&&... ts) {
 } // namespace
 
 namespace yume::ast {
+
+struct {
+} Slice;
+
 auto operator&(std::unique_ptr<Type> type, Qualifier qual) { return ::ast<QualType>(std::move(type), qual); }
+auto operator&(std::unique_ptr<Type> type, decltype(Slice) /* tag */) {
+  std::vector<yume::ast::AnyType> type_args = {};
+  type_args.emplace_back(std::move(type));
+  return ::ast<TemplatedType>(::ast<SimpleType>("Slice"), std::move(type_args));
+}
 } // namespace yume::ast
 
 #define CHECK_PARSER(body, ...) CHECK_THAT(*prog(body), equals_ast(__VA_ARGS__))


### PR DESCRIPTION
This means that T[] is already rewritten to Slice{T} in the parser stage