### PR TITLE
Feature: annotations

### DIFF
--- a/src/yume/ast/clone.cpp
+++ b/src/yume/ast/clone.cpp
@@ -68,7 +68,7 @@ auto VarDecl::clone() const -> VarDecl* { return new VarDecl(tok(), m_name, dup(
 auto FnDecl::clone() const -> FnDecl* {
   return std::visit(
       [&](auto& s) {
-        return new FnDecl(tok(), m_name, dup(m_args), m_type_args, dup(m_ret), dup(s), m_extern_linkage);
+        return new FnDecl(tok(), m_name, dup(m_args), m_type_args, dup(m_ret), dup(s), dup(m_annotations));
       },
       m_body);
 }

--- a/src/yume/ast/parser.hpp
+++ b/src/yume/ast/parser.hpp
@@ -94,6 +94,7 @@ static const TokenAtom KWD_PRIMITIVE = {Token::Type::Word, "__primitive__"_a};
 static const TokenAtom SYM_COMMA = {Token::Type::Symbol, ","_a};
 static const TokenAtom SYM_DOT = {Token::Type::Symbol, "."_a};
 static const TokenAtom SYM_EQ = {Token::Type::Symbol, "="_a};
+static const TokenAtom SYM_AT = {Token::Type::Symbol, "@"_a};
 static const TokenAtom SYM_LPAREN = {Token::Type::Symbol, "("_a};
 static const TokenAtom SYM_RPAREN = {Token::Type::Symbol, ")"_a};
 static const TokenAtom SYM_LBRACKET = {Token::Type::Symbol, "["_a};

--- a/src/yume/ast/visit.cpp
+++ b/src/yume/ast/visit.cpp
@@ -19,9 +19,11 @@ void ReturnStmt::visit(Visitor& visitor) const { visitor.visit(m_expr); }
 void WhileStmt::visit(Visitor& visitor) const { visitor.visit(m_cond).visit(m_body); }
 void VarDecl::visit(Visitor& visitor) const { visitor.visit(m_name).visit(m_type).visit(m_init); }
 void FnDecl::visit(Visitor& visitor) const {
-  visitor.visit(m_name).visit(m_args, "arg").visit(m_type_args, "type arg").visit(m_ret, "ret");
-  if (m_extern_linkage)
-    visitor.visit("extern linkage");
+  visitor.visit(m_name)
+      .visit(m_args, "arg")
+      .visit(m_type_args, "type arg")
+      .visit(m_annotations, "annotation")
+      .visit(m_ret, "ret");
 
   if (const auto* s = get_if<string>(&m_body); s) {
     visitor.visit(*s, "primitive");

--- a/src/yume/diagnostic/visitor/visitor.hpp
+++ b/src/yume/diagnostic/visitor/visitor.hpp
@@ -43,9 +43,11 @@ public:
     return visit(*any_base, label);
   }
 
-  template <typename T> auto visit(const vector<T>& vector, const char* label = nullptr) -> Visitor& {
+  template <std::ranges::range Range>
+  auto visit(const Range& iter, const char* label = nullptr)
+      -> Visitor& requires(!std::convertible_to<Range, const char*>) {
     Visitor& vis = *this;
-    for (auto& i : vector) {
+    for (auto& i : iter) {
       vis = move(vis.visit(i, label));
     }
     return vis;

--- a/src/yume/token.cpp
+++ b/src/yume/token.cpp
@@ -188,7 +188,7 @@ public:
               {Token::Type::Symbol, is_exactly("!=")},
               {Token::Type::Symbol, is_exactly("//")},
               {Token::Type::Symbol, is_exactly("::")},
-              {Token::Type::Symbol, is_any_of(R"(()[]{}<>=:#%-+.,!/*&\)")},
+              {Token::Type::Symbol, is_any_of(R"(()[]{}<>=:#%-+.,!/*&@\)")},
           })) {
         string message = "Tokenizer didn't recognize ";
         message += m_last;


### PR DESCRIPTION
Annotations begin with an at-sign (`@`)

For now, only one valid annotation exists, `@extern`, replacing __extern__