### PR TITLE
Feat: const

### DIFF
--- a/example/const.ym
+++ b/example/const.ym
@@ -1,9 +1,15 @@
 const FOO I32 = 5
-const BAR I16 = I16(7) # TODO: this cast shouldn't be necessary
+
+struct Thing()
+  const FOO I32 = 11
+  const BAR I16 = I16(7) # TODO: this cast shouldn't be necessary
+end
 
 def main() I32
   assert($FOO == 5)
-  assert($BAR == 7)
-  printf("%d + %d = %d\n".c_str.unsafe_ptr, $FOO, $BAR, $FOO + $BAR)
+  assert(Thing::BAR == 7)
+  assert(Thing::FOO == 11)
+  assert($FOO != Thing::FOO)
+  printf("%d + %d = %d\n".c_str.unsafe_ptr, $FOO, Thing::BAR, $FOO + Thing::BAR)
   return 0
 end

--- a/example/const.ym
+++ b/example/const.ym
@@ -1,0 +1,9 @@
+const FOO I32 = 5
+const BAR I16 = I16(7) # TODO: this cast shouldn't be necessary
+
+def main() I32
+  assert($FOO == 5)
+  assert($BAR == 7)
+  printf("%d + %d = %d\n".c_str.unsafe_ptr, $FOO, $BAR, $FOO + $BAR)
+  return 0
+end

--- a/lib/std.ym
+++ b/lib/std.ym
@@ -80,6 +80,8 @@ def ==(a I64, b I64) Bool = __primitive__(ib_icmp_eq)
 def ==(a I32, b I32) Bool = __primitive__(ib_icmp_eq)
 def ==(a U8, b U8) Bool = __primitive__(ib_icmp_eq)
 
+def !=(a I64, b I64) Bool = __primitive__(ib_icmp_ne)
+def !=(a I32, b I32) Bool = __primitive__(ib_icmp_ne)
 def !=(a U8, b U8) Bool = __primitive__(ib_icmp_ne)
 
 def >(a I32, b I32) Bool = __primitive__(ib_icmp_sgt)

--- a/src/yume/ast/ast.hpp
+++ b/src/yume/ast/ast.hpp
@@ -485,13 +485,15 @@ public:
 /// A constant. Currently global
 class ConstExpr : public Expr {
   string m_name;
+  optional<string> m_parent;
 
 public:
-  explicit ConstExpr(span<Token> tok, string name) : Expr(K_Const, tok), m_name(move(name)) {}
+  explicit ConstExpr(span<Token> tok, string name, optional<string> parent) : Expr(K_Const, tok), m_name(move(name)), m_parent(move(parent)) {}
   void visit(Visitor& visitor) const override;
   [[nodiscard]] auto describe() const -> string override;
 
   [[nodiscard]] auto name() const -> string { return m_name; }
+  [[nodiscard]] auto parent() const -> optional<string> { return m_parent; }
   static auto classof(const AST* a) -> bool { return a->kind() == K_Const; }
   [[nodiscard]] auto clone() const -> ConstExpr* override;
 };

--- a/src/yume/ast/clone.cpp
+++ b/src/yume/ast/clone.cpp
@@ -65,6 +65,7 @@ auto BoolExpr::clone() const -> BoolExpr* { return new BoolExpr(tok(), m_val); }
 auto ReturnStmt::clone() const -> ReturnStmt* { return new ReturnStmt(tok(), dup(m_expr)); }
 auto WhileStmt::clone() const -> WhileStmt* { return new WhileStmt(tok(), dup(m_cond), dup(m_body)); }
 auto VarDecl::clone() const -> VarDecl* { return new VarDecl(tok(), m_name, dup(m_type), dup(m_init)); }
+auto ConstDecl::clone() const -> ConstDecl* { return new ConstDecl(tok(), m_name, dup(m_type), dup(m_init)); }
 auto FnDecl::clone() const -> FnDecl* {
   return std::visit(
       [&](auto& s) {
@@ -84,6 +85,7 @@ auto ProxyType::clone() const -> ProxyType* { return new ProxyType(tok(), m_fiel
 auto TypeName::clone() const -> TypeName* { return new TypeName(tok(), dup(type), name); }
 auto Compound::clone() const -> Compound* { return new Compound(tok(), dup(m_body)); }
 auto VarExpr::clone() const -> VarExpr* { return new VarExpr(tok(), m_name); }
+auto ConstExpr::clone() const -> ConstExpr* { return new ConstExpr(tok(), m_name); }
 auto CallExpr::clone() const -> CallExpr* { return new CallExpr(tok(), m_name, dup(m_args)); }
 auto CtorExpr::clone() const -> CtorExpr* { return new CtorExpr(tok(), dup(m_type), dup(m_args)); }
 auto DtorExpr::clone() const -> DtorExpr* { return new DtorExpr(tok(), dup(m_base)); }

--- a/src/yume/ast/clone.cpp
+++ b/src/yume/ast/clone.cpp
@@ -85,7 +85,7 @@ auto ProxyType::clone() const -> ProxyType* { return new ProxyType(tok(), m_fiel
 auto TypeName::clone() const -> TypeName* { return new TypeName(tok(), dup(type), name); }
 auto Compound::clone() const -> Compound* { return new Compound(tok(), dup(m_body)); }
 auto VarExpr::clone() const -> VarExpr* { return new VarExpr(tok(), m_name); }
-auto ConstExpr::clone() const -> ConstExpr* { return new ConstExpr(tok(), m_name); }
+auto ConstExpr::clone() const -> ConstExpr* { return new ConstExpr(tok(), m_name, m_parent); }
 auto CallExpr::clone() const -> CallExpr* { return new CallExpr(tok(), m_name, dup(m_args)); }
 auto CtorExpr::clone() const -> CtorExpr* { return new CtorExpr(tok(), dup(m_type), dup(m_args)); }
 auto DtorExpr::clone() const -> DtorExpr* { return new DtorExpr(tok(), dup(m_base)); }

--- a/src/yume/ast/crtp_walker.hpp
+++ b/src/yume/ast/crtp_walker.hpp
@@ -33,6 +33,7 @@ public:
     case ast::K_If: return conv_statement<ast::IfStmt>(stat, args...);
     case ast::K_Return: return conv_statement<ast::ReturnStmt>(stat, args...);
     case ast::K_VarDecl: return conv_statement<ast::VarDecl>(stat, args...);
+    case ast::K_ConstDecl: return conv_statement<ast::ConstDecl>(stat, args...);
     case ast::K_FnDecl: return conv_statement<ast::FnDecl>(stat, args...);
     case ast::K_StructDecl: return conv_statement<ast::StructDecl>(stat, args...);
     case ast::K_CtorDecl: return conv_statement<ast::CtorDecl>(stat, args...);
@@ -49,6 +50,7 @@ public:
     case ast::K_Bool: return conv_expression<ast::BoolExpr>(expr, args...);
     case ast::K_Call: return conv_expression<ast::CallExpr>(expr, args...);
     case ast::K_Var: return conv_expression<ast::VarExpr>(expr, args...);
+    case ast::K_Const: return conv_expression<ast::ConstExpr>(expr, args...);
     case ast::K_Assign: return conv_expression<ast::AssignExpr>(expr, args...);
     case ast::K_Ctor: return conv_expression<ast::CtorExpr>(expr, args...);
     // case ast::K_Dtor: return conv_expression<ast::DtorExpr>(expr, args...);

--- a/src/yume/ast/describe.cpp
+++ b/src/yume/ast/describe.cpp
@@ -36,6 +36,7 @@ auto CharExpr::describe() const -> string { return std::to_string(m_val); }
 auto BoolExpr::describe() const -> string { return m_val ? "true" : "false"; }
 auto StringExpr::describe() const -> string { return m_val; }
 auto VarExpr::describe() const -> string { return m_name; }
+auto ConstExpr::describe() const -> string { return m_name; }
 auto CallExpr::describe() const -> string { return m_name; }
 auto CtorExpr::describe() const -> string { return m_type->describe(); }
 auto DtorExpr::describe() const -> string { return m_base->describe(); }
@@ -44,4 +45,5 @@ auto FnDecl::describe() const -> string { return m_name; }
 auto CtorDecl::describe() const -> string { return ":new"; }
 auto StructDecl::describe() const -> string { return m_name; }
 auto VarDecl::describe() const -> string { return m_name; }
+auto ConstDecl::describe() const -> string { return m_name; }
 } // namespace yume::ast

--- a/src/yume/ast/parser.cpp
+++ b/src/yume/ast/parser.cpp
@@ -145,6 +145,8 @@ auto Parser::parse_stmt() -> unique_ptr<Stmt> {
     stat = parse_struct_decl();
   else if (tokens->is_a(KWD_LET))
     stat = parse_var_decl();
+  else if (tokens->is_a(KWD_CONST))
+    stat = parse_const_decl();
   else if (tokens->is_a(KWD_WHILE))
     stat = parse_while_stmt();
   else if (tokens->is_a(KWD_IF))
@@ -448,6 +450,20 @@ auto Parser::parse_var_decl() -> unique_ptr<VarDecl> {
   return ast_ptr<VarDecl>(entry, name, move(type), move(init));
 }
 
+auto Parser::parse_const_decl() -> unique_ptr<ConstDecl> {
+  auto entry = tokens.begin();
+
+  consume(KWD_CONST);
+  const string name = consume_word();
+  auto type = AnyType{parse_type()};
+
+  consume(SYM_EQ);
+
+  auto init = parse_expr();
+
+  return ast_ptr<ConstDecl>(entry, name, move(type), move(init));
+}
+
 auto Parser::parse_while_stmt() -> unique_ptr<WhileStmt> {
   auto entry = tokens.begin();
 
@@ -587,6 +603,8 @@ auto Parser::parse_primary() -> unique_ptr<Expr> {
     return ast_ptr<BoolExpr>(entry, false);
   if (try_consume(SYM_COLON_COLON))
     return ast_ptr<FieldAccessExpr>(entry, std::nullopt, consume_word());
+  if (try_consume(SYM_DOLLAR))
+    return ast_ptr<ConstExpr>(entry, consume_word());
 
   if (tokens->type == Word) {
     if (try_peek_uword(0)) {

--- a/src/yume/ast/parser.cpp
+++ b/src/yume/ast/parser.cpp
@@ -604,10 +604,16 @@ auto Parser::parse_primary() -> unique_ptr<Expr> {
   if (try_consume(SYM_COLON_COLON))
     return ast_ptr<FieldAccessExpr>(entry, std::nullopt, consume_word());
   if (try_consume(SYM_DOLLAR))
-    return ast_ptr<ConstExpr>(entry, consume_word());
+    return ast_ptr<ConstExpr>(entry, consume_word(), std::nullopt);
 
   if (tokens->type == Word) {
     if (try_peek_uword(0)) {
+      if (try_peek(1, SYM_COLON_COLON)) {
+        auto parent = consume_word();
+        consume(SYM_COLON_COLON);
+        return ast_ptr<ConstExpr>(entry, consume_word(), parent);
+      }
+
       auto type = parse_type();
       if (try_consume(SYM_LPAREN)) {
         auto call_args = vector<AnyExpr>{};

--- a/src/yume/ast/parser.hpp
+++ b/src/yume/ast/parser.hpp
@@ -83,6 +83,7 @@ static const TokenAtom KWD_THEN = {Token::Type::Word, "then"_a};
 static const TokenAtom KWD_TRUE = {Token::Type::Word, "true"_a};
 static const TokenAtom KWD_FALSE = {Token::Type::Word, "false"_a};
 static const TokenAtom KWD_WHILE = {Token::Type::Word, "while"_a};
+static const TokenAtom KWD_CONST = {Token::Type::Word, "const"_a};
 static const TokenAtom KWD_STRUCT = {Token::Type::Word, "struct"_a};
 static const TokenAtom KWD_RETURN = {Token::Type::Word, "return"_a};
 static const TokenAtom KWD_EXTERN = {Token::Type::Word, "__extern__"_a};
@@ -112,6 +113,7 @@ static const TokenAtom SYM_STAR = {Token::Type::Symbol, "*"_a};
 static const TokenAtom SYM_BANG = {Token::Type::Symbol, "!"_a};
 static const TokenAtom SYM_COLON = {Token::Type::Symbol, ":"_a};
 static const TokenAtom SYM_COLON_COLON = {Token::Type::Symbol, "::"_a};
+static const TokenAtom SYM_DOLLAR = {Token::Type::Symbol, "$"_a};
 
 class TokenRange {
   span<Token> m_span;
@@ -250,6 +252,8 @@ struct Parser {
   auto parse_ctor_decl() -> unique_ptr<CtorDecl>;
 
   auto parse_var_decl() -> unique_ptr<VarDecl>;
+
+  auto parse_const_decl() -> unique_ptr<ConstDecl>;
 
   auto parse_while_stmt() -> unique_ptr<WhileStmt>;
 

--- a/src/yume/ast/visit.cpp
+++ b/src/yume/ast/visit.cpp
@@ -18,6 +18,7 @@ void BoolExpr::visit(Visitor& visitor) const { visitor.visit(describe()); }
 void ReturnStmt::visit(Visitor& visitor) const { visitor.visit(m_expr); }
 void WhileStmt::visit(Visitor& visitor) const { visitor.visit(m_cond).visit(m_body); }
 void VarDecl::visit(Visitor& visitor) const { visitor.visit(m_name).visit(m_type).visit(m_init); }
+void ConstDecl::visit(Visitor& visitor) const { visitor.visit(m_name).visit(m_type).visit(m_init); }
 void FnDecl::visit(Visitor& visitor) const {
   visitor.visit(m_name)
       .visit(m_args, "arg")
@@ -46,6 +47,7 @@ void ProxyType::visit(Visitor& visitor) const { visitor.visit(m_field); }
 void TypeName::visit(Visitor& visitor) const { visitor.visit(name).visit(type); }
 void Compound::visit(Visitor& visitor) const { visitor.visit(m_body); }
 void VarExpr::visit(Visitor& visitor) const { visitor.visit(m_name); }
+void ConstExpr::visit(Visitor& visitor) const { visitor.visit(m_name); }
 void CallExpr::visit(Visitor& visitor) const { visitor.visit(m_name).visit(m_args); }
 void CtorExpr::visit(Visitor& visitor) const { visitor.visit(m_type).visit(m_args); }
 void DtorExpr::visit(Visitor& visitor) const { visitor.visit(m_base); }

--- a/src/yume/ast/visit.cpp
+++ b/src/yume/ast/visit.cpp
@@ -47,7 +47,7 @@ void ProxyType::visit(Visitor& visitor) const { visitor.visit(m_field); }
 void TypeName::visit(Visitor& visitor) const { visitor.visit(name).visit(type); }
 void Compound::visit(Visitor& visitor) const { visitor.visit(m_body); }
 void VarExpr::visit(Visitor& visitor) const { visitor.visit(m_name); }
-void ConstExpr::visit(Visitor& visitor) const { visitor.visit(m_name); }
+void ConstExpr::visit(Visitor& visitor) const { visitor.visit(m_name).visit(m_parent); }
 void CallExpr::visit(Visitor& visitor) const { visitor.visit(m_name).visit(m_args); }
 void CtorExpr::visit(Visitor& visitor) const { visitor.visit(m_type).visit(m_args); }
 void DtorExpr::visit(Visitor& visitor) const { visitor.visit(m_base); }

--- a/src/yume/compiler/compiler.cpp
+++ b/src/yume/compiler/compiler.cpp
@@ -247,9 +247,7 @@ auto Compiler::decl_statement(ast::Stmt& stmt, optional<ty::Type> parent, ast::P
     return &ctor;
   }
   if (auto* const_decl = dyn_cast<ast::ConstDecl>(&stmt)) {
-    // TODO(rymiel): revisit
-    yume_assert(!parent.has_value(), "Constants must currently be at the top level;");
-    auto& cn = m_consts.emplace_back(*const_decl, member);
+    auto& cn = m_consts.emplace_back(*const_decl, parent, member);
 
     return &cn;
   }
@@ -655,7 +653,7 @@ template <> auto Compiler::expression(const ast::VarExpr& expr) -> Val {
 
 template <> auto Compiler::expression(const ast::ConstExpr& expr) -> Val {
   for (const auto& cn : m_consts) {
-    if (cn.name() == expr.name())
+    if (cn.referred_to_by(expr))
       return m_builder->CreateLoad(llvm_type(cn.ast().ensure_ty()), cn.llvm, "cn." + expr.name());
   }
 

--- a/src/yume/compiler/compiler.cpp
+++ b/src/yume/compiler/compiler.cpp
@@ -141,8 +141,10 @@ void Compiler::run() {
   // Fifth pass: convert everything else, but only when instantiated
   m_walker->in_depth = true;
 
-  for (auto& cn : m_consts)
+  for (auto& cn : m_consts) {
+    walk_types(&cn);
     define(cn);
+  }
 
   // Find all external functions. These will be the "entrypoints".
   vector<Fn*> extern_fns = {};

--- a/src/yume/compiler/compiler.hpp
+++ b/src/yume/compiler/compiler.hpp
@@ -46,6 +46,7 @@ class Compiler : public CRTPWalker<Compiler> {
   std::deque<Fn> m_fns{};
   std::deque<Struct> m_structs{};
   std::deque<Fn> m_ctors{};
+  std::deque<Const> m_consts{};
   std::queue<DeclLike> m_decl_queue{};
   unique_ptr<semantic::TypeWalker> m_walker;
 
@@ -79,6 +80,7 @@ public:
 
   /// Compile the body of a function or constructor.
   void define(Fn&);
+  void define(Const&);
 
   void body_statement(const ast::Stmt&);
   auto decl_statement(ast::Stmt&, optional<ty::Type> parent = std::nullopt, ast::Program* member = nullptr) -> DeclLike;

--- a/src/yume/compiler/vals.cpp
+++ b/src/yume/compiler/vals.cpp
@@ -52,6 +52,7 @@ auto Struct::get_or_create_instantiation(Substitution& subs) noexcept -> std::pa
 
 auto Fn::name() const noexcept -> string { return ast().name(); }
 auto Struct::name() const noexcept -> string { return st_ast.name(); }
+auto Const::name() const noexcept -> string { return cn_ast.name(); }
 
 auto Fn::ret() const -> optional<ty::Type> {
   if (auto* fn_decl = dyn_cast<ast::FnDecl>(&ast_decl)) {

--- a/src/yume/semantic/type_walker.cpp
+++ b/src/yume/semantic/type_walker.cpp
@@ -466,12 +466,14 @@ template <> void TypeWalker::statement(ast::VarDecl& stat) {
 }
 
 template <> void TypeWalker::statement(ast::ConstDecl& stat) {
-  body_expression(*stat.init());
   expression(*stat.type());
-  // TODO(rymiel): Perform literal casts
-  make_implicit_conversion(stat.init(), stat.type()->val_ty());
-  stat.init()->attach_to(stat.type().raw_ptr());
-  stat.val_ty(stat.init()->ensure_ty());
+  if (in_depth) {
+    body_expression(*stat.init());
+    // TODO(rymiel): Perform literal casts
+    make_implicit_conversion(stat.init(), stat.type()->val_ty());
+    stat.init()->attach_to(stat.type().raw_ptr());
+  }
+  stat.val_ty(stat.type()->ensure_ty());
 }
 
 template <> void TypeWalker::statement(ast::IfStmt& stat) {

--- a/src/yume/semantic/type_walker.cpp
+++ b/src/yume/semantic/type_walker.cpp
@@ -196,7 +196,7 @@ template <> void TypeWalker::expression(ast::VarExpr& expr) {
 
 template <> void TypeWalker::expression(ast::ConstExpr& expr) {
   for (const auto& cn : compiler.m_consts) {
-    if (cn.name() == expr.name())
+    if (cn.referred_to_by(expr))
       return expr.val_ty(cn.ast().ensure_ty());
   }
   throw std::runtime_error("Nonexistent constant called "s + expr.name());

--- a/src/yume/token.cpp
+++ b/src/yume/token.cpp
@@ -208,7 +208,7 @@ public:
               {Token::Type::Symbol, is_exactly("!="sv)},
               {Token::Type::Symbol, is_exactly("//"sv)},
               {Token::Type::Symbol, is_exactly("::"sv)},
-              {Token::Type::Symbol, is_any_of(R"(()[]{}<>=:#%-+.,!/*&@\)"sv)},
+              {Token::Type::Symbol, is_any_of(R"(()[]{}<>=:#%-+.,!/*&@$\)"sv)},
           })) {
         string message = "Tokenizer didn't recognize ";
         message += m_last;


### PR DESCRIPTION
Add *global* constants. Works towards #20

Currently, these constants are extremely strict: they must be constants according to LLVM, that is, `llvm::Constant*`. Constants must also explicitly specify their type.

Note that currently refering to a constant requires a dollar sign in front, for example:

```ym
const FOO I32 = 5

def foo() I32
  return $FOO
end
```

This is likely to change in the future.