### PR TITLE
Lambdas!

### DIFF
--- a/bin/ci.sh
+++ b/bin/ci.sh
@@ -9,10 +9,10 @@ case $1 in
     status=0
     for i in example/*; do
       [[ -f "${i}" ]] || continue
-      echo "Running example ${i}"
+      echo "[INFO] Running example ${i}"
       "${BUILD_DIR}"/yumec "${i}" || { status=1; continue; }
       mv output.ll result-"$(basename "${i}")".ll
-      ./yume.out || { status=1; continue; }
+      ./yume.out || { status=$?; echo "[FAIL] ${i} exited with $?"; continue; }
     done
     exit "${status}";;
 

--- a/example/lambda.ym
+++ b/example/lambda.ym
@@ -2,7 +2,8 @@ def main() I32
   let lambda = ->(i I32) I32 i + 1
   let x I32 = lambda->(2)
   assert(x == 3)
-  let y I32 = lambda->(lambda->(4))
+  let lambda2 ->(I32)I32 = lambda
+  let y I32 = lambda2->(lambda2->(4))
   assert(y == 6)
   return 0
 end

--- a/example/lambda.ym
+++ b/example/lambda.ym
@@ -1,0 +1,8 @@
+def main() I32
+  let lambda = ->(i I32) I32 i + 1
+  let x I32 = lambda->(2)
+  assert(x == 3)
+  let y I32 = lambda->(lambda->(4))
+  assert(y == 6)
+  return 0
+end

--- a/example/lambda.ym
+++ b/example/lambda.ym
@@ -1,5 +1,5 @@
 def main() I32
-  let lambda = ->(i I32) I32 i + 1
+  let lambda = def(i I32) I32 = i + 1
   let x I32 = lambda->(2)
   assert(x == 3)
   let lambda2 ->(I32)I32 = lambda

--- a/example/lambda.ym
+++ b/example/lambda.ym
@@ -5,5 +5,6 @@ def main() I32
   let lambda2 ->(I32)I32 = lambda
   let y I32 = lambda2->(lambda2->(4))
   assert(y == 6)
+
   return 0
 end

--- a/example/lambda_capture.ym
+++ b/example/lambda_capture.ym
@@ -6,5 +6,6 @@ def main() I32
   let i = 0
   let lambda = ->(j I32) i = i + j
   invoke(lambda)
-  return i
+  assert(i == 2)
+  return 0
 end

--- a/example/lambda_capture.ym
+++ b/example/lambda_capture.ym
@@ -1,0 +1,10 @@
+def invoke(fn ->(I32))
+  fn->(2)
+end
+
+def main() I32
+  let i = 0
+  let lambda = ->(j I32) i = i + j
+  invoke(lambda)
+  return i
+end

--- a/example/lambda_capture.ym
+++ b/example/lambda_capture.ym
@@ -7,5 +7,10 @@ def main() I32
   let lambda = ->(j I32) i = i + j
   invoke(lambda)
   assert(i == 2)
+
+  let slice = I32:[1, 2, 3]
+  slice.each(lambda)
+  assert(i == 8)
+
   return 0
 end

--- a/example/lambda_capture.ym
+++ b/example/lambda_capture.ym
@@ -4,7 +4,7 @@ end
 
 def main() I32
   let i = 0
-  let lambda = ->(j I32) i = i + j
+  let lambda = def(j I32) = (i = i + j)
   invoke(lambda)
   assert(i == 2)
 

--- a/lib/std.ym
+++ b/lib/std.ym
@@ -49,6 +49,14 @@ struct Slice{T}(pointer T ptr, size ISize)
     dup_t[self::size] = last
     return dup_t
   end
+
+  def each(self, fn ->(T))
+    let i = 0
+    while i < self::size
+      fn->(self::pointer[i])
+      i = i + 1
+    end
+  end
 end
 
 def []{T}(ptr T ptr, offset ISize) T mut = __primitive__(get_at)

--- a/src/yume/ast/ast.hpp
+++ b/src/yume/ast/ast.hpp
@@ -617,6 +617,8 @@ class LambdaExpr : public Expr {
   vector<TypeName> m_args;
   OptionalType m_ret;
   AnyStmt m_body;
+  vector<string> m_closured_names{};
+  vector<AST*> m_closured_nodes{};
 
 public:
   LambdaExpr(span<Token> tok, vector<TypeName> args, OptionalType ret, AnyStmt body)
@@ -630,6 +632,10 @@ public:
   [[nodiscard]] auto ret() -> auto& { return m_ret; }
   [[nodiscard]] auto body() const -> const auto& { return m_body; }
   [[nodiscard]] auto body() -> auto& { return m_body; }
+  [[nodiscard]] auto closured_names() const -> const auto& { return m_closured_names; }
+  [[nodiscard]] auto closured_names() -> auto& { return m_closured_names; }
+  [[nodiscard]] auto closured_nodes() const -> const auto& { return m_closured_nodes; }
+  [[nodiscard]] auto closured_nodes() -> auto& { return m_closured_nodes; }
 
   static auto classof(const AST* a) -> bool { return a->kind() == K_Lambda; }
   [[nodiscard]] auto clone() const -> LambdaExpr* override;

--- a/src/yume/ast/ast.hpp
+++ b/src/yume/ast/ast.hpp
@@ -612,35 +612,6 @@ public:
   [[nodiscard]] auto clone() const -> SliceExpr* override;
 };
 
-/// A local definition of an anonymous function
-class LambdaExpr : public Expr {
-  vector<TypeName> m_args;
-  OptionalType m_ret;
-  AnyStmt m_body;
-  vector<string> m_closured_names{};
-  vector<AST*> m_closured_nodes{};
-
-public:
-  LambdaExpr(span<Token> tok, vector<TypeName> args, OptionalType ret, AnyStmt body)
-      : Expr(K_Lambda, tok), m_args(move(args)), m_ret(move(ret)), m_body(move(body)) {}
-  void visit(Visitor& visitor) const override;
-  // [[nodiscard]] auto describe() const -> string override; // TODO(rymiel)
-
-  [[nodiscard]] auto args() const -> const auto& { return m_args; }
-  [[nodiscard]] auto args() -> auto& { return m_args; }
-  [[nodiscard]] auto ret() const -> const auto& { return m_ret; }
-  [[nodiscard]] auto ret() -> auto& { return m_ret; }
-  [[nodiscard]] auto body() const -> const auto& { return m_body; }
-  [[nodiscard]] auto body() -> auto& { return m_body; }
-  [[nodiscard]] auto closured_names() const -> const auto& { return m_closured_names; }
-  [[nodiscard]] auto closured_names() -> auto& { return m_closured_names; }
-  [[nodiscard]] auto closured_nodes() const -> const auto& { return m_closured_nodes; }
-  [[nodiscard]] auto closured_nodes() -> auto& { return m_closured_nodes; }
-
-  static auto classof(const AST* a) -> bool { return a->kind() == K_Lambda; }
-  [[nodiscard]] auto clone() const -> LambdaExpr* override;
-};
-
 /// A "direct" call to an anonymous function
 class DirectCallExpr : public Expr {
   AnyExpr m_base;
@@ -739,6 +710,35 @@ public:
   [[nodiscard]] auto body() -> auto& { return m_body; }
   static auto classof(const AST* a) -> bool { return a->kind() == K_Compound; }
   [[nodiscard]] auto clone() const -> Compound* override;
+};
+
+/// A local definition of an anonymous function
+class LambdaExpr final : public Expr {
+  vector<TypeName> m_args;
+  OptionalType m_ret;
+  Compound m_body;
+  vector<string> m_closured_names{};
+  vector<AST*> m_closured_nodes{};
+
+public:
+  LambdaExpr(span<Token> tok, vector<TypeName> args, OptionalType ret, Compound body)
+      : Expr(K_Lambda, tok), m_args(move(args)), m_ret(move(ret)), m_body(move(body)) {}
+  void visit(Visitor& visitor) const override;
+  // [[nodiscard]] auto describe() const -> string override; // TODO(rymiel)
+
+  [[nodiscard]] auto args() const -> const auto& { return m_args; }
+  [[nodiscard]] auto args() -> auto& { return m_args; }
+  [[nodiscard]] auto ret() const -> const auto& { return m_ret; }
+  [[nodiscard]] auto ret() -> auto& { return m_ret; }
+  [[nodiscard]] auto body() const -> const auto& { return m_body; }
+  [[nodiscard]] auto body() -> auto& { return m_body; }
+  [[nodiscard]] auto closured_names() const -> const auto& { return m_closured_names; }
+  [[nodiscard]] auto closured_names() -> auto& { return m_closured_names; }
+  [[nodiscard]] auto closured_nodes() const -> const auto& { return m_closured_nodes; }
+  [[nodiscard]] auto closured_nodes() -> auto& { return m_closured_nodes; }
+
+  static auto classof(const AST* a) -> bool { return a->kind() == K_Lambda; }
+  [[nodiscard]] auto clone() const -> LambdaExpr* override;
 };
 
 /// Base class for a named declaration.

--- a/src/yume/ast/ast.hpp
+++ b/src/yume/ast/ast.hpp
@@ -73,6 +73,7 @@ enum Kind {
   /**/ K_SimpleType,    ///< `SimpleType`
   /**/ K_QualType,      ///< `QualType`
   /**/ K_TemplatedType, ///< `TemplatedType`
+  /**/ K_FunctionType,  ///< `TemplatedType`
   /**/ K_SelfType,      ///< `SelfType`
   /**/ K_ProxyType,     ///< `ProxyType`
   /**/ K_END_Type,
@@ -94,6 +95,7 @@ auto inline constexpr kind_name(Kind type) -> const char* {
   case K_SimpleType: return "simple type";
   case K_QualType: return "qual type";
   case K_TemplatedType: return "templated type";
+  case K_FunctionType: return "function type";
   case K_SelfType: return "self type";
   case K_ProxyType: return "proxy type";
   case K_TypeName: return "type name";
@@ -386,6 +388,25 @@ public:
 
   static auto classof(const AST* a) -> bool { return a->kind() == K_ProxyType; }
   [[nodiscard]] auto clone() const -> ProxyType* override;
+};
+
+/// A function type \e i.e. `->(Foo,Bar)Baz`.
+class FunctionType : public Type {
+  OptionalType m_ret;
+  vector<AnyType> m_args;
+
+public:
+  FunctionType(span<Token> tok, OptionalType ret, vector<AnyType> args)
+      : Type(K_FunctionType, tok), m_ret{move(ret)}, m_args{move(args)} {}
+  void visit(Visitor& visitor) const override;
+  [[nodiscard]] auto describe() const -> string override;
+
+  [[nodiscard]] auto ret() const -> const auto& { return m_ret; }
+  [[nodiscard]] auto ret() -> auto& { return m_ret; }
+  [[nodiscard]] auto args() const -> const auto& { return m_args; }
+  [[nodiscard]] auto args() -> auto& { return m_args; }
+  static auto classof(const AST* a) -> bool { return a->kind() == K_FunctionType; }
+  [[nodiscard]] auto clone() const -> FunctionType* override;
 };
 
 /// A pair of a `Type` and an identifier, \e i.e. a parameter name.

--- a/src/yume/ast/clone.cpp
+++ b/src/yume/ast/clone.cpp
@@ -82,6 +82,7 @@ auto QualType::clone() const -> QualType* { return new QualType(tok(), dup(m_bas
 auto TemplatedType::clone() const -> TemplatedType* { return new TemplatedType(tok(), dup(m_base), dup(m_type_args)); }
 auto SelfType::clone() const -> SelfType* { return new SelfType(tok()); }
 auto ProxyType::clone() const -> ProxyType* { return new ProxyType(tok(), m_field); }
+auto FunctionType::clone() const -> FunctionType* { return new FunctionType(tok(), dup(m_ret), dup(m_args)); }
 auto TypeName::clone() const -> TypeName* { return new TypeName(tok(), dup(type), name); }
 auto Compound::clone() const -> Compound* { return new Compound(tok(), dup(m_body)); }
 auto VarExpr::clone() const -> VarExpr* { return new VarExpr(tok(), m_name); }

--- a/src/yume/ast/clone.cpp
+++ b/src/yume/ast/clone.cpp
@@ -90,6 +90,8 @@ auto CallExpr::clone() const -> CallExpr* { return new CallExpr(tok(), m_name, d
 auto CtorExpr::clone() const -> CtorExpr* { return new CtorExpr(tok(), dup(m_type), dup(m_args)); }
 auto DtorExpr::clone() const -> DtorExpr* { return new DtorExpr(tok(), dup(m_base)); }
 auto SliceExpr::clone() const -> SliceExpr* { return new SliceExpr(tok(), dup(m_type), dup(m_args)); }
+auto LambdaExpr::clone() const -> LambdaExpr* { return new LambdaExpr(tok(), dup(m_args), dup(m_ret), dup(m_body)); }
+auto DirectCallExpr::clone() const -> DirectCallExpr* { return new DirectCallExpr(tok(), dup(m_base), dup(m_args)); }
 auto AssignExpr::clone() const -> AssignExpr* { return new AssignExpr(tok(), dup(m_target), dup(m_value)); }
 auto FieldAccessExpr::clone() const -> FieldAccessExpr* { return new FieldAccessExpr(tok(), dup(m_base), m_field); }
 auto ImplicitCastExpr::clone() const -> ImplicitCastExpr* {

--- a/src/yume/ast/crtp_walker.hpp
+++ b/src/yume/ast/crtp_walker.hpp
@@ -51,6 +51,8 @@ public:
     case ast::K_Call: return conv_expression<ast::CallExpr>(expr, args...);
     case ast::K_Var: return conv_expression<ast::VarExpr>(expr, args...);
     case ast::K_Const: return conv_expression<ast::ConstExpr>(expr, args...);
+    case ast::K_Lambda: return conv_expression<ast::LambdaExpr>(expr, args...);
+    case ast::K_DirectCall: return conv_expression<ast::DirectCallExpr>(expr, args...);
     case ast::K_Assign: return conv_expression<ast::AssignExpr>(expr, args...);
     case ast::K_Ctor: return conv_expression<ast::CtorExpr>(expr, args...);
     // case ast::K_Dtor: return conv_expression<ast::DtorExpr>(expr, args...);

--- a/src/yume/ast/describe.cpp
+++ b/src/yume/ast/describe.cpp
@@ -30,6 +30,19 @@ auto TemplatedType::describe() const -> string {
 auto SimpleType::describe() const -> string { return m_name; }
 auto SelfType::describe() const -> string { return "self"; }
 auto ProxyType::describe() const -> string { return m_field; }
+auto FunctionType::describe() const -> string {
+  stringstream ss{};
+  ss << "->(";
+  for (const auto& i : llvm::enumerate(m_args)) {
+    if (i.index() > 0)
+      ss << ",";
+    ss << i.value()->describe();
+  }
+  ss << ")";
+  if (m_ret.has_value())
+    ss << m_ret->describe();
+  return ss.str();
+}
 auto TypeName::describe() const -> string { return name; }
 auto NumberExpr::describe() const -> string { return std::to_string(m_val); }
 auto CharExpr::describe() const -> string { return std::to_string(m_val); }

--- a/src/yume/ast/parser.hpp
+++ b/src/yume/ast/parser.hpp
@@ -239,6 +239,7 @@ struct Parser {
 
   auto parse_fn_arg() -> FnArg;
 
+  auto try_parse_function_type() -> optional<unique_ptr<FunctionType>>;
   auto try_parse_type() -> optional<unique_ptr<Type>>;
   auto parse_type(bool implicit_self = false) -> unique_ptr<Type>;
 

--- a/src/yume/ast/parser.hpp
+++ b/src/yume/ast/parser.hpp
@@ -113,6 +113,7 @@ static const TokenAtom SYM_STAR = {Token::Type::Symbol, "*"_a};
 static const TokenAtom SYM_BANG = {Token::Type::Symbol, "!"_a};
 static const TokenAtom SYM_COLON = {Token::Type::Symbol, ":"_a};
 static const TokenAtom SYM_COLON_COLON = {Token::Type::Symbol, "::"_a};
+static const TokenAtom SYM_ARROW = {Token::Type::Symbol, "->"_a};
 static const TokenAtom SYM_DOLLAR = {Token::Type::Symbol, "$"_a};
 
 class TokenRange {
@@ -233,7 +234,7 @@ struct Parser {
   /// Check if the ahead by `ahead` is a capitalized word.
   [[nodiscard]] auto try_peek_uword(int ahead, source_location location = source_location::current()) const -> bool;
 
-  auto parse_stmt() -> unique_ptr<Stmt>;
+  auto parse_stmt(bool require_sep = true) -> unique_ptr<Stmt>;
   auto parse_expr() -> unique_ptr<Expr>;
 
   auto parse_fn_arg() -> FnArg;
@@ -274,6 +275,8 @@ struct Parser {
   auto parse_receiver() -> unique_ptr<Expr>;
 
   auto parse_unary() -> unique_ptr<Expr>;
+
+  auto parse_lambda() -> unique_ptr<LambdaExpr>;
 
   template <size_t N = 0> auto parse_operator() -> unique_ptr<Expr> {
     auto entry = tokens.begin();

--- a/src/yume/ast/visit.cpp
+++ b/src/yume/ast/visit.cpp
@@ -52,6 +52,8 @@ void CallExpr::visit(Visitor& visitor) const { visitor.visit(m_name).visit(m_arg
 void CtorExpr::visit(Visitor& visitor) const { visitor.visit(m_type).visit(m_args); }
 void DtorExpr::visit(Visitor& visitor) const { visitor.visit(m_base); }
 void SliceExpr::visit(Visitor& visitor) const { visitor.visit(m_type).visit(m_args); }
+void LambdaExpr::visit(Visitor& visitor) const { visitor.visit(m_args).visit(m_ret).visit(m_body); }
+void DirectCallExpr::visit(Visitor& visitor) const { visitor.visit(m_base).visit(m_args); }
 void AssignExpr::visit(Visitor& visitor) const { visitor.visit(m_target).visit(m_value); }
 void FieldAccessExpr::visit(Visitor& visitor) const { visitor.visit(m_base).visit(m_field); }
 void ImplicitCastExpr::visit(Visitor& visitor) const { visitor.visit(m_conversion.to_string()).visit(m_base); }

--- a/src/yume/ast/visit.cpp
+++ b/src/yume/ast/visit.cpp
@@ -43,6 +43,7 @@ void StructDecl::visit(Visitor& visitor) const {
 void SimpleType::visit(Visitor& visitor) const { visitor.visit(m_name); }
 void QualType::visit(Visitor& visitor) const { visitor.visit(m_base, describe().c_str()); }
 void TemplatedType::visit(Visitor& visitor) const { visitor.visit(m_base).visit(m_type_args, "type arg"); }
+void FunctionType::visit(Visitor& visitor) const { visitor.visit(m_ret).visit(m_args); }
 void ProxyType::visit(Visitor& visitor) const { visitor.visit(m_field); }
 void TypeName::visit(Visitor& visitor) const { visitor.visit(name).visit(type); }
 void Compound::visit(Visitor& visitor) const { visitor.visit(m_body); }

--- a/src/yume/compiler/compiler.cpp
+++ b/src/yume/compiler/compiler.cpp
@@ -918,17 +918,9 @@ template <> auto Compiler::expression(const ast::LambdaExpr& expr) -> Val {
     expose_parameter_as_local(type, name, *ast_arg, arg);
   }
 
-  if (const auto* body_expr = dyn_cast<ast::Expr>(expr.body().raw_ptr())) {
-    auto expr_val = body_expression(*body_expr);
-    if (m_builder->GetInsertBlock()->getTerminator() == nullptr) {
-      if (fn_ty->m_ret.has_value())
-        m_builder->CreateRet(expr_val);
-      else
-        m_builder->CreateRetVoid();
-    }
-  } else {
-    body_statement(*expr.body());
-  }
+  body_statement(expr.body());
+  if (m_builder->GetInsertBlock()->getTerminator() == nullptr && !fn_ty->m_ret.has_value())
+    m_builder->CreateRetVoid();
 
   m_scope = saved_scope;
   m_builder->SetInsertPoint(saved_insert_point);

--- a/src/yume/compiler/compiler.cpp
+++ b/src/yume/compiler/compiler.cpp
@@ -40,6 +40,7 @@
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Target/TargetOptions.h>
+// TODO(LLVM MIN >= 14): remove workaround
 #if __has_include(<llvm/MC/TargetRegistry.h>)
 #include <llvm/MC/TargetRegistry.h>
 #else
@@ -885,6 +886,7 @@ template <> auto Compiler::expression(const ast::LambdaExpr& expr) -> Val {
                            m_builder->CreateConstInBoundsGEP2_32(llvm_closure_ty, llvm_closure, 0, i.index()));
   }
 
+  // TODO(LLVM MIN >= 15): BitCast obsoleted by opaque pointers
   fn_bundle =
       m_builder->CreateInsertValue(fn_bundle, m_builder->CreateBitCast(llvm_closure, m_builder->getInt8PtrTy()), 1);
 
@@ -898,6 +900,7 @@ template <> auto Compiler::expression(const ast::LambdaExpr& expr) -> Val {
 
   // Skip the first argument when allocating local parameters. It is the closure type and unpacked earlier.
   auto llvm_fn_args = llvm::make_range(llvm_fn->arg_begin() + 1, llvm_fn->arg_end());
+  // TODO(LLVM MIN >= 15): BitCast obsoleted by opaque pointers
   Val closure_val =
       m_builder->CreateLoad(llvm_closure_ty, m_builder->CreateBitCast(llvm_fn->arg_begin(), m_builder->getInt8PtrTy()));
 

--- a/src/yume/compiler/compiler.hpp
+++ b/src/yume/compiler/compiler.hpp
@@ -125,6 +125,8 @@ private:
   /// scope.
   void make_temporary_in_scope(Val& val, const ast::AST& ast, const string& name = "tmp"s);
 
+  void expose_parameter_as_local(ty::Type type, const string& name, const ast::AST& ast, Val val);
+
   auto create_malloc(llvm::Type* base_type, Val slice_size, string_view name = ""sv) -> Val;
   auto create_malloc(llvm::Type* base_type, uint64_t slice_size, string_view name = ""sv) -> Val;
 

--- a/src/yume/compiler/type_holder.cpp
+++ b/src/yume/compiler/type_holder.cpp
@@ -35,4 +35,13 @@ void TypeHolder::declare_size_type(Compiler& compiler) {
     known.insert({i_ty->name(), move(i_ty)});
   }
 }
+
+auto TypeHolder::find_or_create_fn_type(const vector<ty::Type>& args, optional<ty::Type> ret) -> ty::Function* {
+  for (const auto& i : fn_types)
+    if (i->ret() == ret && i->args() == args)
+      return i.get();
+
+  auto& new_fn = fn_types.emplace_back(std::make_unique<ty::Function>("", args, ret));
+  return new_fn.get();
+}
 } // namespace yume

--- a/src/yume/compiler/type_holder.cpp
+++ b/src/yume/compiler/type_holder.cpp
@@ -36,12 +36,13 @@ void TypeHolder::declare_size_type(Compiler& compiler) {
   }
 }
 
-auto TypeHolder::find_or_create_fn_type(const vector<ty::Type>& args, optional<ty::Type> ret) -> ty::Function* {
+auto TypeHolder::find_or_create_fn_type(const vector<ty::Type>& args, optional<ty::Type> ret,
+                                        const vector<ty::Type>& closure) -> ty::Function* {
   for (const auto& i : fn_types)
-    if (i->ret() == ret && i->args() == args)
+    if (i->ret() == ret && i->args() == args && i->closure() == closure)
       return i.get();
 
-  auto& new_fn = fn_types.emplace_back(std::make_unique<ty::Function>("", args, ret));
+  auto& new_fn = fn_types.emplace_back(std::make_unique<ty::Function>("", args, ret, closure));
   return new_fn.get();
 }
 } // namespace yume

--- a/src/yume/compiler/type_holder.hpp
+++ b/src/yume/compiler/type_holder.hpp
@@ -18,6 +18,7 @@ struct TypeHolder {
   ty::Int* bool_type{};
   IntTypePair size_type{};
   llvm::StringMap<unique_ptr<ty::BaseType>> known{};
+  std::vector<unique_ptr<ty::Function>> fn_types{};
   std::vector<unique_ptr<ty::BaseType>> template_instantiations{};
 
   TypeHolder();

--- a/src/yume/compiler/type_holder.hpp
+++ b/src/yume/compiler/type_holder.hpp
@@ -29,5 +29,7 @@ struct TypeHolder {
   constexpr auto int16() -> IntTypePair { return int_types[1]; }
   constexpr auto int32() -> IntTypePair { return int_types[2]; }
   constexpr auto int64() -> IntTypePair { return int_types[3]; }
+
+  auto find_or_create_fn_type(const vector<ty::Type>& args, optional<ty::Type> ret) -> ty::Function*;
 };
 } // namespace yume

--- a/src/yume/compiler/type_holder.hpp
+++ b/src/yume/compiler/type_holder.hpp
@@ -30,6 +30,7 @@ struct TypeHolder {
   constexpr auto int32() -> IntTypePair { return int_types[2]; }
   constexpr auto int64() -> IntTypePair { return int_types[3]; }
 
-  auto find_or_create_fn_type(const vector<ty::Type>& args, optional<ty::Type> ret) -> ty::Function*;
+  auto find_or_create_fn_type(const vector<ty::Type>& args, optional<ty::Type> ret, const vector<ty::Type>& closure)
+      -> ty::Function*;
 };
 } // namespace yume

--- a/src/yume/semantic/type_walker.cpp
+++ b/src/yume/semantic/type_walker.cpp
@@ -198,7 +198,7 @@ template <> void TypeWalker::expression(ast::LambdaExpr& expr) {
       ret_type = expr.ret()->ensure_ty();
     }
 
-    body_statement(*expr.body());
+    body_statement(expr.body());
 
     auto closured_types = vector<ty::Type>();
     for (const auto& i : closured) {

--- a/src/yume/semantic/type_walker.hpp
+++ b/src/yume/semantic/type_walker.hpp
@@ -33,9 +33,17 @@ struct TypeWalker : public CRTPWalker<TypeWalker, false> {
   friend CRTPWalker;
 
 public:
+  struct ASTWithName {
+    ast::AST* ast;
+    string name;
+  };
+
   Compiler& compiler;
   DeclLike current_decl{};
-  ScopeContainer<nonnull<ast::AST*>> scope{};
+  using scope_t = ScopeContainer<nonnull<ast::AST*>>;
+  scope_t scope{};
+  vector<scope_t> enclosing_scopes{};
+  vector<ASTWithName> closured{};
 
   std::queue<DeclLike> decl_queue{};
 
@@ -63,10 +71,12 @@ private:
     auto saved_scope = scope;
     auto saved_current_decl = current_decl;
     auto saved_depth = in_depth;
+    auto saved_closured = closured;
 
     callback();
 
     // Restore again
+    closured = saved_closured;
     in_depth = saved_depth;
     current_decl = saved_current_decl;
     scope = saved_scope;

--- a/src/yume/token.cpp
+++ b/src/yume/token.cpp
@@ -208,6 +208,7 @@ public:
               {Token::Type::Symbol, is_exactly("!="sv)},
               {Token::Type::Symbol, is_exactly("//"sv)},
               {Token::Type::Symbol, is_exactly("::"sv)},
+              {Token::Type::Symbol, is_exactly("->"sv)},
               {Token::Type::Symbol, is_any_of(R"(()[]{}<>=:#%-+.,!/*&@$\)"sv)},
           })) {
         string message = "Tokenizer didn't recognize ";

--- a/src/yume/ty/type.cpp
+++ b/src/yume/ty/type.cpp
@@ -277,6 +277,21 @@ auto Struct::name() const -> string {
   return ss.str();
 }
 
+auto Function::name() const -> string {
+  auto ss = stringstream{};
+  ss << "->" << base_name() << "(";
+  for (const auto& i : llvm::enumerate(m_args)) {
+    if (i.index() > 0)
+      ss << ",";
+    ss << i.value().name();
+  }
+  ss << ")";
+  if (m_ret.has_value())
+    ss << m_ret->name();
+
+  return ss.str();
+}
+
 namespace detail {
 static constexpr size_t BITSIZE_8 = 8;
 static constexpr size_t BITSIZE_16 = 16;

--- a/src/yume/ty/type.hpp
+++ b/src/yume/ty/type.hpp
@@ -44,6 +44,7 @@ public:
 
 /// A "qualified" type, with a stackable qualifier, \e i.e. `ptr`.
 class Ptr : public BaseType {
+  // TODO(rymiel): why are these here?
   friend BaseType;
 
 private:
@@ -69,6 +70,7 @@ class Struct final : public BaseType {
   mutable llvm::StructType* m_memo{};
   void memo(llvm::StructType* memo) const { m_memo = memo; }
 
+  // TODO(rymiel): why are these here?
   friend Compiler;
   friend BaseType;
   friend Type;
@@ -88,22 +90,32 @@ public:
 class Function : public BaseType {
   vector<Type> m_args;
   optional<Type> m_ret;
+  vector<Type> m_closure;
 
-  mutable llvm::FunctionType* m_memo{};
-  void memo(llvm::FunctionType* memo) const { m_memo = memo; }
+  mutable llvm::FunctionType* m_fn_memo{};
+  void fn_memo(llvm::FunctionType* memo) const { m_fn_memo = memo; }
+  mutable llvm::StructType* m_closure_memo{};
+  void closure_memo(llvm::StructType* memo) const { m_closure_memo = memo; }
+  mutable llvm::StructType* m_memo{};
+  void memo(llvm::StructType* memo) const { m_memo = memo; }
 
+  // TODO(rymiel): why are these here?
   friend Compiler;
   friend BaseType;
   friend Type;
 
 public:
-  Function(string name, vector<Type> args, optional<Type> ret)
-      : BaseType(K_Function, move(name)), m_args(move(args)), m_ret(ret) {}
+  Function(string name, vector<Type> args, optional<Type> ret, vector<Type> closure)
+      : BaseType(K_Function, move(name)), m_args(move(args)), m_ret(ret), m_closure(move(closure)) {}
   [[nodiscard]] auto args() const -> const auto& { return m_args; }
   [[nodiscard]] auto args() -> auto& { return m_args; }
+  [[nodiscard]] auto closure() const -> const auto& { return m_closure; }
+  [[nodiscard]] auto closure() -> auto& { return m_closure; }
   [[nodiscard]] auto ret() const -> const auto& { return m_ret; }
   [[nodiscard]] auto name() const -> string override;
 
+  [[nodiscard]] auto fn_memo() const -> auto* { return m_fn_memo; }
+  [[nodiscard]] auto closure_memo() const -> auto* { return m_closure_memo; }
   [[nodiscard]] auto memo() const -> auto* { return m_memo; }
   static auto classof(const BaseType* a) -> bool { return a->kind() == K_Function; }
 };

--- a/src/yume/ty/type.hpp
+++ b/src/yume/ty/type.hpp
@@ -14,13 +14,14 @@
 
 namespace llvm {
 class StructType;
-}
+class FunctionType;
+} // namespace llvm
 namespace yume {
 class Compiler;
 struct Instantiation;
 namespace ast {
 struct TypeName;
-}
+} // namespace ast
 } // namespace yume
 
 namespace yume::ty {
@@ -81,6 +82,30 @@ public:
   [[nodiscard]] auto name() const -> string override;
   [[nodiscard]] auto memo() const -> auto* { return m_memo; }
   static auto classof(const BaseType* a) -> bool { return a->kind() == K_Struct; }
+};
+
+/// A function pointer type
+class Function : public BaseType {
+  vector<Type> m_args;
+  optional<Type> m_ret;
+
+  mutable llvm::FunctionType* m_memo{};
+  void memo(llvm::FunctionType* memo) const { m_memo = memo; }
+
+  friend Compiler;
+  friend BaseType;
+  friend Type;
+
+public:
+  Function(string name, vector<Type> args, optional<Type> ret)
+      : BaseType(K_Function, move(name)), m_args(move(args)), m_ret(ret) {}
+  [[nodiscard]] auto args() const -> const auto& { return m_args; }
+  [[nodiscard]] auto args() -> auto& { return m_args; }
+  [[nodiscard]] auto ret() const -> const auto& { return m_ret; }
+  [[nodiscard]] auto name() const -> string override;
+
+  [[nodiscard]] auto memo() const -> auto* { return m_memo; }
+  static auto classof(const BaseType* a) -> bool { return a->kind() == K_Function; }
 };
 
 /// An unsubstituted generic type variable, usually something like `T`.

--- a/src/yume/ty/type_base.hpp
+++ b/src/yume/ty/type_base.hpp
@@ -13,11 +13,12 @@ struct Sub;
 class Type;
 
 enum Kind {
-  K_Unknown, ///< `UnknownType`, default, zero value. Hopefully never encountered!
-  K_Int,     ///< `Int`
-  K_Ptr,     ///< `Ptr`
-  K_Struct,  ///< `Struct`
-  K_Generic, ///< `Generic`
+  K_Unknown,  ///< `UnknownType`, default, zero value. Hopefully never encountered!
+  K_Int,      ///< `Int`
+  K_Ptr,      ///< `Ptr`
+  K_Struct,   ///< `Struct`
+  K_Function, ///< `Function`
+  K_Generic,  ///< `Generic`
 };
 
 /// Represents a type in the type system.


### PR DESCRIPTION
Syntax is a work in progress.
Current syntax: function types `->(T, U) R` (a function taking a T and U, returning R)
lambda definitions `def(arg ArgT) RetT = lambda_body` (follows the same `=` meaning short body rule as function declarations)
lambda invocation `lambda->(args)` (there should be no need for the arrow here)

```ym
let lambda = def (i I32) I32 = i + 1
let x I32 = lambda->(2)
assert(x == 3)
```

Lambdas may contain captures, which are stored in a closure object and passed along with the function pointer.

```ym
def invoke(fn ->(I32))
  fn->(2)
end

let i = 0
let lambda = def(j I32) = (i = i + j)
invoke(lambda)
assert(i == 2)
```

Note that there isn't yet any safety, such as ensuring captured values do not outlive the values they reference